### PR TITLE
Update awsiotsdk version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
--f https://qqaatw.github.io/aws-crt-python-musllinux/
-awsiotsdk==1.12.0
+awsiotsdk==1.15.4
 httpx
 paho-mqtt

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with open("README.md", "r", encoding="utf-8") as f:
     long_description = f.read()
 
 install_requires = [
-    "awsiotsdk==1.12.0", # See: https://github.com/pypa/pip/issues/5898
+    "awsiotsdk==1.15.4",
     "httpx",
     "paho-mqtt",
 ]


### PR DESCRIPTION
1. awsiotsdk `1.15.4` ships musllinux binary wheels to PyPi. By updating it, we no longer need to specify a custom index link in order to get the binary wheels.