### PR TITLE
check noneType before using it

### DIFF
--- a/JciHitachi/api.py
+++ b/JciHitachi/api.py
@@ -950,7 +950,7 @@ class JciHitachiAWSAPI:
     def _check_before_publish(self) -> None:
         # Reauthenticate 5 mins before AWSTokens expiration.
         current_time = time.time()
-        if self._aws_tokens.expiration - current_time <= 300:
+        if self._aws_tokens is None or (self._aws_tokens.expiration - current_time <= 300):
             self.reauth()
 
         if self._mqtt.mqtt_events.mqtt_error_event.is_set():


### PR DESCRIPTION
fixed the error below:

File "/usr/local/lib/python3.12/site-packages/JciHitachi/api.py", line 1293, in set_status
self._check_before_publish()
File "/usr/local/lib/python3.12/site-packages/JciHitachi/api.py", line 953, in _check_before_publish
if self._aws_tokens.expiration - current_time <= 300:
^^^^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'NoneType' object has no attribute 'expiration'