### PR TITLE
Bump httpx version to 0.28.0 and Bump paho-mqtt version to 2.0.0

### DIFF
--- a/JciHitachi/connection.py
+++ b/JciHitachi/connection.py
@@ -1,5 +1,6 @@
 import json
 import os
+import ssl
 
 import httpx
 
@@ -12,7 +13,9 @@ API_SSL_CERT = os.path.join(
     os.path.dirname(os.path.abspath(__file__)),
     "cert/api-jci-hitachi-smarthome-com-chain.pem",
 )
-API_SSL_CONTEXT = httpx.create_ssl_context()
+API_SSL_CONTEXT = ssl.create_default_context()
+if hasattr(API_SSL_CONTEXT, "verify_flags"):
+    API_SSL_CONTEXT.verify_flags &= ~ssl.VERIFY_X509_STRICT
 API_SSL_CONTEXT.load_verify_locations(cafile=API_SSL_CERT)
 API_SSL_CONTEXT.set_ciphers(
     "DEFAULT@SECLEVEL=1"

--- a/JciHitachi/mqtt_connection.py
+++ b/JciHitachi/mqtt_connection.py
@@ -18,6 +18,8 @@ MQTT_SSL_CERT = os.path.join(
     "cert/mqtt-jci-hitachi-smarthome-com-chain.pem",
 )
 MQTT_SSL_CONTEXT = ssl.create_default_context(cafile=MQTT_SSL_CERT)
+if hasattr(MQTT_SSL_CONTEXT, "verify_flags"):
+    MQTT_SSL_CONTEXT.verify_flags &= ~ssl.VERIFY_X509_STRICT
 MQTT_SSL_CONTEXT.set_ciphers(
     "DEFAULT@SECLEVEL=1"
 )  # the cert uses SHA1-RSA1024bits ciphers so unfortunately we have to lower the security level
@@ -55,7 +57,7 @@ class JciHitachiMqttConnection:  # pragma: no cover
         self._user_id = user_id
         self._print_response = print_response
 
-        self._mqttc = mqtt.Client()
+        self._mqttc = mqtt.Client(mqtt.CallbackAPIVersion.VERSION1)
         self._mqtt_events = JciHitachiMqttEvents()
 
     def __del__(self):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 awsiotsdk>=1.22.0
-httpx<0.28.0
-paho-mqtt<=1.6.1
+httpx>=0.28.0
+paho-mqtt>=2.0.0
 setuptools


### PR DESCRIPTION
In response to the requirements of Home Assistant Core 2025.3.0

Fixes https://github.com/qqaatw/JciHitachiHA/issues/97