### PR TITLE
Fix: Handle non-UTF8 characters in MQTT payload decoding

### DIFF
--- a/JciHitachi/aws_connection.py
+++ b/JciHitachi/aws_connection.py
@@ -574,7 +574,7 @@ class JciHitachiAWSMqttConnection:
 
     def _on_publish(self, topic: str, payload: bytes, dup, qos, retain, **kwargs):
         try:
-            payload = json.loads(payload.decode(errors='replace'))
+            payload = json.loads(payload.decode(errors="replace"))
         except Exception as e:
             self._mqtt_events.mqtt_error = e.__class__.__name__
             self._mqtt_events.mqtt_error_event.set()

--- a/JciHitachi/aws_connection.py
+++ b/JciHitachi/aws_connection.py
@@ -574,7 +574,7 @@ class JciHitachiAWSMqttConnection:
 
     def _on_publish(self, topic: str, payload: bytes, dup, qos, retain, **kwargs):
         try:
-            payload = json.loads(payload.decode())
+            payload = json.loads(payload.decode(errors='replace'))
         except Exception as e:
             self._mqtt_events.mqtt_error = e.__class__.__name__
             self._mqtt_events.mqtt_error_event.set()


### PR DESCRIPTION
**Problem:**
This PR addresses a UnicodeDecodeError encountered when parsing MQTT message payloads. It has been observed that Hitachi's server sometimes returns non-UTF-8 strings within the payload, specifically in the "Model" field of "registration/response" topics. An example is the presence of a 0xff byte, which prevents proper UTF-8 decoding and leads to the Failed to login API RuntimeError in JciHitachiAWSAPI.refresh_status (as detailed in [qqaatw/JciHitachiHA#106](https://github.com/qqaatw/JciHitachiHA/issues/106)).

**Observed Error Log:**
```
2025-07-09 21:12:05.126 INFO (SyncWorker_1) [JciHitachi.aws_connection] MQTT Connected.
2025-07-09 21:12:07.488 ERROR (Dummy-9) [JciHitachi.aws_connection] Mqtt topic ap-northeast-1:XXXXX/ap-northeast-1:XXXX/registration/response published with payload b'{\n\t"FirmwareId":\t3,\n\t"DeviceType":\t1,\n\t"Model":\t"RAD-\xff\\u0006\\u0001R",\n\t"FindMe":\t10,\n\t"Switch":\t3,\n\t"Mode":\t31,\n\t"FanSpeed":\t31,\n\t"TemperatureSetting":\t4128,\n\t"IndoorTemperature":\t40,\n\t"SleepModeRemainingTime":\t1440,\n\t"ScheduleOn":\t1440,\n\t"ScheduleOff":\t1440,\n\t"MildewProof":\t3,\n\t"QuickMode":\t3,\n\t"PowerSaving":\t3,\n\t"ControlTone":\t3,\n\t"PowerConsumption":\t65535,\n\t"TaiseiaError":\t85,\n\t"FilterElapsedHour":\t800,\n\t"CleanSwitch":\t3,\n\t"CleanNotification":\t3,\n\t"CleanStatus":\t7,\n\t"Checksum":\t245,\n\t"IndoorUnitInfo":\t"H65535V256",\n\t"OutdoorUnitInfo":\t"H65535V255",\n\t"Error":\t0,\n\t"WiFiSSID":\t"XXXXX",\n\t"FirmwareVersion":\t"6.0.028",\n\t"FirmwareCode":\t49,\n\t"SystemTimestamp":\t80662,\n\t"RequestTimestamp":\t1752066725,\n\t"Timestamp":\t1752066726\n}' cannot be decoded: 'utf-8' codec can't decode byte 0xff in position 53: invalid start byte
2025-07-09 21:12:19.229 ERROR (MainThread) [custom_components.jcihitachi_tw] Failed to login API: An event occurred but wasn't accompanied with data when refreshing 主臥空調 support code.
```

**Solution:**
The fix modifies the `_on_publish` method in `LibJciHitachi/aws_connection.py`. By changing `payload.decode()` to `payload.decode(errors='replace')`, the decoder will now replace any invalid UTF-8 characters with a standard replacement character (), allowing the JSON parsing to proceed without error.

This ensures the robustness of the MQTT message handling, even when the API sends data with unexpected character encodings.

**Code Change:**

**Before (in `_on_publish` method):**
```python
payload = json.loads(payload.decode())
```
After:
```python
payload = json.loads(payload.decode(errors='replace'))
```

**Additional Notes**
This patch successfully resolves the API login issue. However, the 'Model' field in Home Assistant's device list may still display corrupted characters (e.g., RAD-R) due to the errors='replace' handling. Further investigation may be needed to perfectly interpret these specific non-standard characters from the API, if possible.