### PR TITLE
Fix: timed-out support-code request silently treated as successful

### DIFF
--- a/JciHitachi/aws_connection.py
+++ b/JciHitachi/aws_connection.py
@@ -867,7 +867,12 @@ class JciHitachiAWSMqttConnection:
                     support_topic, json.dumps(default_payload), QOS
                 )
                 publish_future.result(timeout)
-                self._mqtt_events.device_support_event[thing_name].wait(timeout)
+                if not self._mqtt_events.device_support_event[thing_name].wait(
+                    timeout
+                ):
+                    raise TimeoutError(
+                        f"Timed out waiting for a support-code response from {thing_name}."
+                    )
 
             self._execution_pools.support_execution_pool.append(
                 self._wrap_async(thing_name, fn)

--- a/JciHitachi/aws_connection.py
+++ b/JciHitachi/aws_connection.py
@@ -867,9 +867,7 @@ class JciHitachiAWSMqttConnection:
                     support_topic, json.dumps(default_payload), QOS
                 )
                 publish_future.result(timeout)
-                if not self._mqtt_events.device_support_event[thing_name].wait(
-                    timeout
-                ):
+                if not self._mqtt_events.device_support_event[thing_name].wait(timeout):
                     raise TimeoutError(
                         f"Timed out waiting for a support-code response from {thing_name}."
                     )

--- a/tests/test_aws_connection.py
+++ b/tests/test_aws_connection.py
@@ -209,7 +209,26 @@ class TestJciHitachiAWSMqttConnection:
             with pytest.raises(ValueError, match="Invalid publish_type: others"):
                 mqtt.publish("", thing_name, "others")
 
-        # TODO: test timeout
+        # test support timeout
+        import asyncio
+
+        async def run_support_test():
+            mqtt._mqtt_events.device_support_event[thing_name] = threading.Event()
+            with patch.object(mqtt, "_mqttc") as mock_mqttc:
+                publish_future = concurrent.futures.Future()
+                publish_future.set_result(None)
+                mock_mqttc.publish.return_value = (publish_future, None)
+                mqtt.publish("", thing_name, "support", timeout=0.01)
+                exec_pool = mqtt._execution_pools.support_execution_pool
+                results = await asyncio.gather(*exec_pool, return_exceptions=True)
+                mqtt._execution_pools.support_execution_pool.clear()
+                assert isinstance(results[0], TimeoutError)
+                assert (
+                    f"Timed out waiting for a support-code response from {thing_name}"
+                    in str(results[0])
+                )
+
+        asyncio.run(run_support_test())
 
     @pytest.mark.parametrize("raise_exception", [False, True])
     def test_publish_shadow(self, fixture_aws_mock_mqtt_connection, raise_exception):


### PR DESCRIPTION
Fixes the root cause behind #40 (and the same symptom in the older closed reports #38/#31/#40 on `JciHitachiHA`).

## Root cause

In `JciHitachiAWSMqttConnection.publish()`, the `"support"` branch's inner `fn()` called:

```python
self._mqtt_events.device_support_event[thing_name].wait(timeout)
```

...and discarded the return value. `threading.Event.wait(timeout)` returns `False` on a genuine timeout, but since `_wrap_async()` always returns the `thing_name` identifier unconditionally (regardless of what `fn()` internally observed), `execute()`'s `support_results` ends up containing the thing name **even when the device never responded at all**.

This violates `execute()`'s own documented contract ("Each result is a list containing thing names if the execution was successful **or `BaseException`(s) if an error occurred**") and causes `refresh_status()` to take the wrong branch when gathering results — it sees `thing.thing_name in support_results`, assumes a response arrived, and raises:

```
RuntimeError: An event occurred but wasn't accompanied with data when refreshing <name> support code.
```

...instead of correctly falling into the `else` branch that already exists for this exact case, with a much more accurate and actionable message:

```
RuntimeError: Timed out refreshing <name> support code. Please ensure the device is online and avoid opening the official app.
```

So the fix is small: make the timeout actually raise inside `fn()`, so `asyncio.gather(..., return_exceptions=True)` correctly captures it as an exception rather than a false-positive success.

## Fix

```python
def fn():
    publish_future, _ = self._mqttc.publish(
        support_topic, json.dumps(default_payload), QOS
    )
    publish_future.result(timeout)
    if not self._mqtt_events.device_support_event[thing_name].wait(timeout):
        raise TimeoutError(
            f"Timed out waiting for a support-code response from {thing_name}."
        )
```

## Testing

Verified against a real account with two devices — one that reproducibly fails this exact way (3/3 attempts, isolated via `device_names=`) and one that reliably succeeds (3/3 attempts). Results:

| | Before patch | After patch |
|---|---|---|
| Failing device, alone | `RuntimeError: ...wasn't accompanied with data...` | `RuntimeError: Timed out refreshing... Please ensure the device is online...` (correct, existing message) |
| Working device, alone (regression check, 3x) | `LOGIN OK` | `LOGIN OK` (unchanged) |

No behavior change for devices that respond normally — this only changes what happens when a device's support-code request never gets a response, replacing a misleading error with the message the code already intended to show in that case.

## Scope note

The `"status"` and `"control"` branches of the same `publish()` method have the identical discard-the-wait-result pattern and likely have the same latent issue. I scoped this PR to just `"support"` since that's the specific reported/reproduced case — happy to open a follow-up for the other two if that's wanted, but didn't want to change more behavior than I could actually verify against a live reproduction.
